### PR TITLE
as-map method missing for objects of Projection type

### DIFF
--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -247,6 +247,10 @@
   UpdateTableResult   (as-map [r] (as-map (.getTableDescription r)))
   DeleteTableResult   (as-map [r] (as-map (.getTableDescription r)))
 
+  Projection
+  (as-map [p] {:projection-type    (.getProjectionType p)
+               :non-key-attributes (.getNonKeyAttributes p)})
+
   LocalSecondaryIndexDescription
   (as-map [d] {:name       (keyword (.getIndexName d))
                :size       (.getIndexSizeBytes d)


### PR DESCRIPTION
Projection is not implementing AsMap protocol resulting in exceptions when creating tables with local secondary indexes . The tables are created but at the end an exception rise when the table info is displayed .
