### PR TITLE
Use DefaultAWSCredentialsProviderChain when access-key and explicit credentials are not present

### DIFF
--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -68,6 +68,7 @@
              ResourceNotFoundException]
             com.amazonaws.ClientConfiguration
             com.amazonaws.auth.BasicAWSCredentials
+            com.amazonaws.auth.DefaultAWSCredentialsProviderChain
             com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
             java.nio.ByteBuffer))
 
@@ -83,8 +84,9 @@
    (fn [{:keys [credentials access-key secret-key endpoint proxy-host proxy-port
                conn-timeout max-conns max-error-retry socket-timeout] :as creds}]
      (if (empty? creds) (AmazonDynamoDBClient.) ; Use credentials provider chain
-       (let [aws-creds     (or credentials ; Use explicit, pre-constructed creds
-                               (BasicAWSCredentials. access-key secret-key))
+       (let [aws-creds     (cond credentials credentials ; Use explicit, pre-constructed creds
+                                 access-key (BasicAWSCredentials. access-key secret-key)
+                                 :else (DefaultAWSCredentialsProviderChain.))
              client-config (doto-cond [g (ClientConfiguration.)]
                              proxy-host      (.setProxyHost         g)
                              proxy-port      (.setProxyPort         g)


### PR DESCRIPTION
Currently faraday will only default to using the DefaultAWSCredentialsProviderChain if _no client options_ are specified (the map is empty). It's nice if faraday uses DefaultAWSCredentialsProviderChain whenever credentials can't be found, even when other options are specified.

This change means that users don't need to create their own DefaultAWSCredentialsProviderChain instance and pass it in using the `:credentials` key.
