### PR TITLE
list-tables support for > 100 tables

### DIFF
--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -336,10 +336,12 @@
   [client-opts]
   (letfn [(step [^String offset]
             (lazy-seq
-             (let [chunk (if (nil? offset)
-                    (mapv keyword (.getTableNames (.listTables (db-client client-opts))))
-                    (mapv keyword (.getTableNames (.listTables (db-client client-opts) offset))))
-                   last-key (last chunk)]
+             (let [client   (db-client client-opts)
+                   result   (if (nil? offset)
+                              (.listTables client)
+                              (.listTables client offset))
+                   last-key (.getLastEvaluatedTableName result)
+                   chunk    (map keyword (.getTableNames result))]
                (if last-key
                  (concat chunk (step (name last-key)))
                  chunk))))]

--- a/test/taoensso/faraday/tests/main.clj
+++ b/test/taoensso/faraday/tests/main.clj
@@ -103,8 +103,9 @@
       i1 {:id 1 :name "bar"}
       i2 {:id 2 :name "baz"}
       creds        (BasicAWSCredentials. (:access-key *client-opts*) (:secret-key *client-opts*))
-      provider     (StaticCredentialsProvider. creds)]
-  (binding [*client-opts* (merge {:provider provider} (when-let [endpoint (get (System/getenv) "AWS_DYNAMODB_ENDPOINT")] {:endpoint endpoint}))]
+      provider     (StaticCredentialsProvider. creds)
+      endpoint     (get (System/getenv) "AWS_DYNAMODB_ENDPOINT")]
+  (binding [*client-opts* (merge {:provider provider} (when endpoint {:endpoint endpoint}))]
     (far/batch-write-item *client-opts* {ttable {:delete [{:id 0} {:id 1} {:id 2}]}})
     (expect                             ; Batch put
      [i0 i1 nil] (do (far/batch-write-item *client-opts* {ttable {:put [i0 i1]}})
@@ -115,9 +116,13 @@
     ;; test list-tables lazy sequence
     ;; generate more than 100 tables to hit the batch size limit
     ;; of list-tables
-    (let [tables (map keyword (map #(str "test_" %) (range 102)))]
-      (doseq [table tables] (far/ensure-table *client-opts* [:id :n]
-                                              {:throughput  {:read 1 :write 1}
-                                               :block?      true}))
-      (expect true (> (count (far/list-tables *client-opts*)) 100))
-      (doseq [table tables] (far/delete-table *client-opts*)))))
+    ;; since this creates a large number of tables, only run this
+    ;; when the endpoint matches localhost
+    (when (.contains endpoint "localhost")
+      (let [tables (map keyword (map #(str "test_" %) (range 102)))]
+        (doseq [table tables] (far/ensure-table *client-opts* table
+                                                [:id :n]
+                                                {:throughput  {:read 1 :write 1}
+                                                 :block?      true}))
+        (expect true (> (count (far/list-tables *client-opts*)) 100))
+        (doseq [table tables] (far/delete-table *client-opts* table))))))


### PR DESCRIPTION
dynamodb by default only returns 100 results for list-tables.  This patch returns a lazy-seq of results, which continues to pull with the default batch size of 100.  Note, the signature has changed, and this method no longer returns a vector.
