### PR TITLE
Fix regression in scan & query after first page

### DIFF
--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -955,8 +955,10 @@
        :or   {span-reqs {:max 5}}}]]
   (letfn [(run1 [last-prim-kvs]
             (as-map
-             (.query (db-client client-opts)
-              (query-request table prim-key-conds opts))))]
+             (.query
+              (db-client client-opts)
+              (query-request table prim-key-conds
+                             (assoc opts :last-prim-kvs last-prim-kvs)))))]
     (merge-more run1 span-reqs (run1 last-prim-kvs))))
 
 (defn scan-request
@@ -1010,8 +1012,9 @@
        :or   {span-reqs {:max 5}}}]]
   (letfn [(run1 [last-prim-kvs]
             (as-map
-             (.scan (db-client client-opts)
-               (scan-request table opts))))]
+             (.scan
+              (db-client client-opts)
+              (scan-request table (assoc opts :last-prim-kvs last-prim-kvs)))))]
     (merge-more run1 span-reqs (run1 last-prim-kvs))))
 
 (defn scan-parallel


### PR DESCRIPTION
Apologies, just spotted this when looking at reimplementing query & scan asynchronously - the implementations of `run1` in both bodies built a request based on the outer `opts` map, ignoring the passed-in `last-prim-kvs`, which would be different in subsequent invocations by `merge-more`.  Modified to merge the supplied value into `opts`.  It would have been correct only for single pages before, AFAICT.
