### PR TITLE
Add ability to manage TTL on tables

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
    [com.taoensso/encore "2.88.1"]
    [com.taoensso/nippy  "2.12.2"]
    [joda-time           "2.9.6"]
-   [com.amazonaws/aws-java-sdk-dynamodb "1.10.49"
+   [com.amazonaws/aws-java-sdk-dynamodb "1.11.253"
     :exclusions [joda-time]]]
 
   :profiles
@@ -25,7 +25,7 @@
    :1.6  {:dependencies [[org.clojure/clojure "1.6.0"]]}
    :1.7  {:dependencies [[org.clojure/clojure "1.7.0"]]}
    :1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}
-   :1.9  {:dependencies [[org.clojure/clojure "1.9.0-alpha10"]]}
+   :1.9  {:dependencies [[org.clojure/clojure "1.9.0"]]}
    :test {:dependencies [[expectations           "2.1.3"]
                          [org.clojure/test.check "0.9.0"]]
           :plugins [[lein-expectations "0.0.8"]

--- a/run-tests
+++ b/run-tests
@@ -38,6 +38,7 @@ else
     export AWS_DYNAMODB_ACCESS_KEY="test"
     export AWS_DYNAMODB_SECRET_KEY="test"
     export AWS_DYNAMODB_ENDPOINT="http://localhost:6798"
+    export AWS_DYNAMODB_LOCAL=1
   else
     echo "Using $1 for IAM creds..."
     source $1

--- a/test/taoensso/faraday/tests/requests.clj
+++ b/test/taoensso/faraday/tests/requests.clj
@@ -31,6 +31,8 @@
     DescribeStreamRequest
     DescribeTableRequest
     DescribeTableResult
+    DescribeTimeToLiveRequest
+    DescribeTimeToLiveResult
     ExpectedAttributeValue
     GetItemRequest
     GetItemResult
@@ -70,11 +72,15 @@
     ShardIteratorType
     StreamViewType
     TableDescription
+    TimeToLiveDescription
+    TimeToLiveSpecification
     UpdateGlobalSecondaryIndexAction
     UpdateItemRequest
     UpdateItemResult
     UpdateTableRequest
     UpdateTableResult
+    UpdateTimeToLiveRequest
+    UpdateTimeToLiveResult
     WriteRequest]))
 
 (comment
@@ -101,6 +107,8 @@
 (def describe-stream-request    #'taoensso.faraday/describe-stream-request)
 (def get-shard-iterator-request #'taoensso.faraday/get-shard-iterator-request)
 (def get-records-request        #'taoensso.faraday/get-records-request)
+(def describe-ttl-request       #'taoensso.faraday/describe-ttl-request)
+(def update-ttl-request         #'taoensso.faraday/update-ttl-request)
 
 ;;;;
 
@@ -504,3 +512,16 @@
                                {:limit 50})]
   (expect "arn:aws:dynamodb:us-west-2:111122223333:table/etcetc" (.getShardIterator req))
   (expect 50 (.getLimit req)))
+
+(let [req ^DescribeTimeToLiveRequest (describe-ttl-request
+                                      {:table-name :my-desc-ttl-table})]
+  (expect "my-desc-ttl-table" (.getTableName req)))
+
+(let [req ^UpdateTimeToLiveRequest (update-ttl-request
+                                    {:table-name :my-update-ttl-table
+                                     :enabled? true
+                                     :key-name :ttl})]
+  (expect "my-update-ttl-table" (.getTableName req))
+  (let [ttl-spec (.getTimeToLiveSpecification req)]
+    (expect true (.getEnabled ttl-spec))
+    (expect "ttl" (.getAttributeName ttl-spec))))


### PR DESCRIPTION
Add the following functions:

[updateTimeToLive](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/dynamodbv2/AmazonDynamoDBClient.html#updateTimeToLive-com.amazonaws.services.dynamodbv2.model.UpdateTimeToLiveRequest-) as `update-ttl`
[describeTimeToLive](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/dynamodbv2/AmazonDynamoDBClient.html#describeTimeToLive-com.amazonaws.services.dynamodbv2.model.DescribeTimeToLiveRequest-) as `describe-ttl` 

Notes:
I was required to update the AWS SDK which I can only assume impacted some of the test output. I've tweaked some of the tests without undermining any fundamentals (to the best of my knowledge). I noticed that tests were also failing on a fresh checkout and my alterations meant they were failing for different reasons so I felt obliged to look into it. I believe I've managed to keep all the tests relevant and to the spirit with which they were intended. There are some differences between the local and non-local testing systems which, again, I've tried to cater for.

Tests against local DynamoDB (via `./run-tests local`) failed (it doesn't appear to support the new functions).
```
com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException: 
   An unknown operation was requested.
```    
As a workaround, I have added the `AWS_DYNAMODB_LOCAL` environment variable into the `run-tests` script for when running against a local instance. It omits the new tests which cause the issue. In my opinion the local version of DynamoDB exhibits such varying behaviour now that deprecation of that testing mechanism should be considered.

Tests against _real_ DynamoDB (via `./run-tests my-env`) failed due to 
```
com.amazonaws.services.dynamodbv2.model.LimitExceededException: 
   Subscriber limit exceeded: Only 1 online index can be created or deleted simultaneously per table
```
From what I can see, this problem is occurring on `master` and was not introduced during my PR. My attempt to solve this is with an improved `index-status-watch` function.
