### PR TITLE
[#122] Transaction Support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
    [com.taoensso/encore "2.88.1"]
    [com.taoensso/nippy  "2.12.2"]
    [joda-time           "2.9.6"]
-   [com.amazonaws/aws-java-sdk-dynamodb "1.10.49"
+   [com.amazonaws/aws-java-sdk-dynamodb "1.11.466"
     :exclusions [joda-time]]]
 
   :profiles

--- a/test/taoensso/faraday/tests/main.clj
+++ b/test/taoensso/faraday/tests/main.clj
@@ -137,16 +137,21 @@
       i1 {:id 301 :name "bar"}
       i2 {:id 302 :name "baz"}
       i3 {:id 303 :name "qux"}
-      i4 {:id 304 :name "quux"}]
+      i4 {:id 304 :name "quux"}
+      i5 {:id 305 :name "corge"}
+      i6 {:id 306 :name "grault"}]
 
   (after-setup!
     #(far/batch-write-item *client-opts*
-                           {ttable {:delete [{:id 300} {:id 301} {:id 302} {:id 303}]}}))
+                           {ttable {:delete [{:id 300} {:id 301} {:id 302} {:id 303}
+                                             {:id 304} {:id 305} {:id 306}]}}))
 
   (expect ; Batch put
-   [i0 i1] (do (far/batch-write-item *client-opts* {ttable {:put [i0 i1]}})
-                   [(far/get-item *client-opts* ttable {:id  300})
-                    (far/get-item *client-opts* ttable {:id  301})]))
+   [i0 i1 i5 i6] (do (far/batch-write-item *client-opts* {ttable {:put [i0 i1 i5 i6]}})
+                   [(far/get-item *client-opts* ttable {:id 300})
+                    (far/get-item *client-opts* ttable {:id 301})
+                    (far/get-item *client-opts* ttable {:id 305})
+                    (far/get-item *client-opts* ttable {:id 306})]))
 
   (expect ; Condition Check
    nil
@@ -245,8 +250,18 @@
 
   (expect ; Verify first update results
    "foofoo"
-   (:name (far/get-item *client-opts* ttable {:id 300}))))
+   (:name (far/get-item *client-opts* ttable {:id 300})))
 
+
+
+  (expect ; Transact Get Items
+   [i5 i6]
+   (:items (far/transact-get-items *client-opts*
+                                   {:return-cc? true
+                                    :items [{:table-name ttable
+                                             :prim-kvs {:id 305}}
+                                            {:table-name ttable
+                                             :prim-kvs {:id 306}}]}))))
 
 
 ;;;; Expressions support

--- a/test/taoensso/faraday/tests/main.clj
+++ b/test/taoensso/faraday/tests/main.clj
@@ -203,7 +203,25 @@
 
   (expect ; Verify that Put failed (i4 should not have been written)
    nil
-   (far/get-item *client-opts* ttable {:id  304})))
+   (far/get-item *client-opts* ttable {:id  304}))
+
+  (expect ; Delete
+   nil
+   (far/transact-write-items *client-opts*
+                             {:items [{:delete {:table-name ttable
+                                                :prim-kvs {:id 302}
+                                                :cond-expr "attribute_exists(#id)"
+                                                :expr-attr-names {"#id" "id"}}}
+                                      {:delete {:table-name ttable
+                                                :prim-kvs {:id 303}
+                                                :cond-expr "attribute_exists(#id)"
+                                                :expr-attr-names {"#id" "id"}}}
+                                      ]}))
+
+  (expect ; Verify delete results
+   [nil nil]
+   [(far/get-item *client-opts* ttable {:id  302})
+    (far/get-item *client-opts* ttable {:id  303})]))
 
 
 


### PR DESCRIPTION
Issue #122 

This PR introduces support for Dynamo DB transactions. This is up for initial feedback. 
 - [ ] Inline documentation
 - [x] `TransactWriteItems` is supported with all the operations: 
   - [x] `ConditionCheck`
   - [x] `Put`
   - [x] `Delete`
   - [x] `Update`. 
 - [x] TransactGetItems is supported with the `Get` operation
 - [x] Tests
---

Sample `TransactWriteItems` call:

```clojure
(far/transact-write-items *client-opts*
 {:client-req-token "foobar"
  :return-cc? true
  :items [{:cond-check {:table-name ttable
                        :prim-kvs {:id 300}
                        :cond-expr "attribute_exists(#id)"
                        :expr-attr-names {"#id" "id"}}}
          
          {:put {:table-name ttable
                 :item  i2
                 :cond-expr "attribute_not_exists(#id)"
                 :expr-attr-names {"#id" "id"}}}
          
          {:delete {:table-name ttable
                    :prim-kvs {:id 302}
                    :cond-expr "attribute_exists(#id)"
                    :expr-attr-names {"#id" "id"}}}
          
          {:update {:table-name ttable
                    :prim-kvs  {:id 300}
                    :update-expr "SET #name = :name"
                    :cond-expr "attribute_exists(#id) AND #name = :oldname"
                    :expr-attr-names {"#id" "id", "#name" "name"}
                    :expr-attr-vals  {":oldname" "foo", ":name" "foofoo"}}}]})


```

----
 Sample `TransactGetItems` call:

```clojure
(far/transact-get-items *client-opts*
 {:return-cc? true
  :items [{:table-name ttable
           :prim-kvs {:id 1}}
          {:table-name ttable
           :prim-kvs {:id 2}}]})
```