### PR TITLE
Ensure result metadata is returned for queries & scans

### DIFF
--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -1272,8 +1272,10 @@
                 (db-client client-opts)
                 (query-request table prim-key-conds
                   (assoc opts :last-prim-kvs last-prim-kvs))))
-           [:items] (fn [items] {table items})))]
-    (table (merge-more run1 span-reqs (run1 last-prim-kvs)))))
+            [:items]
+            (fn [items] {table items})))
+        result (merge-more run1 span-reqs (run1 last-prim-kvs))]
+    (with-meta (table result) (meta result))))
 
 (defn- scan-request
   [table
@@ -1349,8 +1351,10 @@
               (.scan
                 (db-client client-opts)
                 (scan-request table (assoc opts :last-prim-kvs last-prim-kvs))))
-            [:items] (fn [items] {table items})))]
-    (table (merge-more run1 span-reqs (run1 last-prim-kvs)))))
+            [:items]
+            (fn [items] {table items})))
+        result (merge-more run1 span-reqs (run1 last-prim-kvs))]
+    (with-meta (table result) (meta result))))
 
 (defn scan-parallel
   "Like `scan` but starts a number of worker threads and automatically handles

--- a/test/taoensso/faraday/tests/main.clj
+++ b/test/taoensso/faraday/tests/main.clj
@@ -589,6 +589,15 @@
                                              :limit           1
                                              :span-reqs       {:max 1}
                                              :expr-attr-vals  {":r" true}}))
+  ;; Paging metadata is returned
+  (expect
+   {:cc-units nil, :last-prim-kvs {:author "George Orwell", :name "Animal Farm"}, :count 1, :scanned-count 1}
+   (meta (far/scan *client-opts* book-table {:filter-expr "#r = :r"
+                                             :expr-attr-names {"#r" "read?"}
+                                             :limit 1
+                                             :span-reqs {:max 1}
+                                             :expr-attr-vals {":r" true}})))
+
   ;; Confirm we combine projection and filter expressions on scan
   (expect
     ["George Orwell" "Arthur C. Clarke"]
@@ -677,6 +686,11 @@
   (expect ; Query with :limit
     [j0] (far/query *client-opts* range-table {:title [:eq "One"]}
            {:limit 1 :span-reqs {:max 1}}))
+
+  (expect ; Query with more results
+   {:cc-units nil, :last-prim-kvs {:number 0N, :title "One"}, :count 1}
+   (meta (far/query *client-opts* range-table {:title [:eq "One"]}
+                    {:limit 1 :span-reqs {:max 1}})))
 
   (expect ; Query, with range
     [k1 k2] (far/query *client-opts* range-table {:title  [:eq "Two"]


### PR DESCRIPTION
Looks like recent PR's introduced this regression - there were _no_ tests covering response meta-data from scans/queries!