### PR TITLE
Allow lazy sequences to be serialized as long as they have been realized

### DIFF
--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -320,7 +320,13 @@
         (enc/revery? enc/stringy? s) (doto (AttributeValue.) (.setSS (mapv enc/as-qname s)))
         (enc/revery? ddb-num?     s) (doto (AttributeValue.) (.setNS (mapv str s)))
         (enc/revery? freeze?      s) (doto (AttributeValue.) (.setBS (mapv nt-freeze s)))
-        :else (throw (Exception. "Invalid DynamoDB value: set of invalid type or more than one type"))))))
+        :else (throw (Exception. "Invalid DynamoDB value: set of invalid type or more than one type")))))
+
+  clojure.lang.LazySeq
+  (serialize [s]
+    (if (.isRealized s)
+      (doto (AttributeValue.) (.setL (mapv serialize s)))
+      (throw (IllegalArgumentException. "Unrealized lazy sequences are not supported. Realize this sequence before calling Faraday (e.g. doall) or replace the sequence with a non-lazy alternative (e.g. 'mapv' instead of 'map', or use 'into []'). Faraday avoids attempting to realize values that might be infinite, since this could cause strange an unexpected problems that are hard to diagnose.")))))
 
 (extend-type (Class/forName "[B")
   ISerializable

--- a/test/taoensso/faraday/tests/main.clj
+++ b/test/taoensso/faraday/tests/main.clj
@@ -1329,3 +1329,16 @@
   (far/put-item *client-opts* range-table {:title "Three" :number 35}
                 {:cond-expr "attribute_not_exists(#t)"
                  :expr-attr-names {"#t" "title"}}))
+
+(deftest lazy-seqs
+
+  (testing "Lazy seq that is not realized cannot be serialized"
+      (is (thrown? IllegalArgumentException
+                   (far/put-item *client-opts* ttable {:id 10 :items (map str (range 5))}))))
+
+  (testing "Lazy seqs that are realized are okay"
+    (far/put-item *client-opts* ttable {:id 10 :items (doall (map str (range 5)))})
+    (is (= ["0" "1" "2" "3" "4"] (:items (far/get-item *client-opts* ttable {:id 10}))))
+
+    (far/put-item *client-opts* ttable {:id 10 :items (mapv str (range 5))})
+    (is (= ["0" "1" "2" "3" "4"] (:items (far/get-item *client-opts* ttable {:id 10}))))))


### PR DESCRIPTION
Until now, including a lazy sequence in item data when serializing would result in an error like:

```
java.lang.IllegalArgumentException:
No implementation of method: :serialize of protocol: #'taoensso.faraday/ISerializable found for class: clojure.lang.LazySeq
```

This is a common failure scenario for new users of Faraday since we tend to create lazy sequences often when transforming data. There's discussion about what Faraday should do with these sequence here: https://github.com/Taoensso/faraday/issues/99.

This change allows a lazy sequence to be serialized and written as long as it has been realized. This seemed like the best compromise.

Closes #99