### PR TITLE
Return :billing-mode :provisioned when BillingModeSummary is nil

### DIFF
--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -436,7 +436,7 @@
      :item-count          (.getItemCount d)
      :size                (.getTableSizeBytes d)
      :throughput          (as-map (.getProvisionedThroughput d))
-     :billing-mode        (as-map (.getBillingModeSummary d))
+     :billing-mode        (as-map (or (.getBillingModeSummary d) (.. (BillingModeSummary.) (withBillingMode "PROVISIONED"))))
      :indexes             (as-map (.getLocalSecondaryIndexes d)) ; DEPRECATED
      :lsindexes           (as-map (.getLocalSecondaryIndexes d))
      :gsindexes           (as-map (.getGlobalSecondaryIndexes d))


### PR DESCRIPTION
The tests have started failing here although there have been no changes to the code. I think DynamoDB Local has changed behaviour (and since clj-dynamodb-local just downloads the latest, we're exposed to this kind of change).

It appears that a table set to provisioned billing mode can return a `nil` billing more summary. Since provisioned is the default, I suppose this is reasonable. I found reports on other projects that indicate people have seen real dynamo tables sometimes behave in this way, so I think it's something that we should accommodate rather than just update the test. 