### PR TITLE
Add support empty string and binary vals

### DIFF
--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -314,9 +314,7 @@
   Keyword (serialize [kw] (serialize (enc/as-qname kw)))
   String
   (serialize [s]
-    (if (.isEmpty s)
-      (throw (Exception. "Invalid DynamoDB value: \"\" (empty string)"))
-      (doto (AttributeValue.) (.setS s))))
+    (doto (AttributeValue.) (.setS s)))
 
   IPersistentVector
   (serialize [v] (doto (AttributeValue.) (.setL (mapv serialize v))))

--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -1684,7 +1684,8 @@
 (def remove-empty-attr-vals
   "Alpha, subject to change.
   Util to help remove (or coerce to nil) empty val types prohibited by DDB,
-  Ref. http://goo.gl/Xg85pO. See also `freeze` as an alternative."
+  Ref. http://goo.gl/Xg85pO. Note that empty string and binary attributes are
+  now permitted: https://amzn.to/3szZ0E5 See also `freeze` as an alternative."
   (let [->?seq (fn [c] (when (seq c) c))]
     (fn f1 [x]
       (cond
@@ -1700,6 +1701,4 @@
             (fn rf [acc in] (let [v* (f1 in)] (if (nil? v*) acc (conj acc v*))))
             (if (sequential? x) [] (empty x)) x))
 
-        (string?    x) (when-not (.isEmpty ^String x)       x)
-        (enc/bytes? x) (when-not (zero? (alength ^bytes x)) x)
         :else x))))

--- a/test/taoensso/faraday/tests/main.clj
+++ b/test/taoensso/faraday/tests/main.clj
@@ -1216,7 +1216,7 @@
              (far/get-item *client-opts* ttable {:id (:id item)}))))))
 
 (deftest removing-empty-attributes
-  (is (= {:b [{:a "b"}], :f false, :g "    "}
+  (is (= {:b [{:a "b"}], :empt-str "", :e #{""}, :f false, :g "    "}
          (far/remove-empty-attr-vals
           {:b [{:a "b" :c [[]] :d #{}}, {}] :a nil :empt-str "" :e #{""} :f false :g "    "}))))
 

--- a/test/taoensso/faraday/tests/main.clj
+++ b/test/taoensso/faraday/tests/main.clj
@@ -1208,6 +1208,13 @@
                :throughput
                (select-keys #{:read :write}))))))
 
+(deftest empty-string
+  (let [item {:id 1 :name ""}]
+    (is (= item
+           (do
+             (far/put-item *client-opts* ttable item)
+             (far/get-item *client-opts* ttable {:id (:id item)}))))))
+
 (deftest removing-empty-attributes
   (is (= {:b [{:a "b"}], :f false, :g "    "}
          (far/remove-empty-attr-vals


### PR DESCRIPTION
As of May 2020, DynamoDB supports empty strings: https://aws.amazon.com/about-aws/whats-new/2020/05/amazon-dynamodb-now-supports-empty-values-for-non-key-string-and-binary-attributes-in-dynamodb-tables/

Per issue #149, this PR removes the check in faraday, so that it no longer fails with `Invalid DynamoDB value: "" (empty string)`.