### PR TITLE
Avoid capturing serialize value in clj-item->db-item

### DIFF
--- a/src/taoensso/faraday.clj
+++ b/src/taoensso/faraday.clj
@@ -363,7 +363,8 @@
 ;;;; Object coercions
 
 (def db-item->clj-item (partial utils/keyword-map deserialize))
-(def clj-item->db-item (partial utils/name-map      serialize))
+(defn clj-item->db-item [item]
+  (utils/name-map serialize item))
 
 (defn- cc-units [^ConsumedCapacity cc] (some-> cc (.getCapacityUnits)))
 (defn- batch-cc-units [ccs]

--- a/test/taoensso/faraday/tests/main.clj
+++ b/test/taoensso/faraday/tests/main.clj
@@ -1578,3 +1578,16 @@
                                                :prim-kvs {:id 305}}
                                               {:table-name ttable
                                                :prim-kvs {:id 306}}]}))))))
+
+(deftype MyType [^long val])
+
+(extend-protocol
+  far/ISerializable
+  MyType
+  (serialize [c]
+    (str "<MyType " (.val c) ">")))
+
+(deftest clj-item->db-item-extensions
+  (testing "Serialize custom types"
+    (is (= (far/clj-item->db-item {:item (MyType. 17)})
+           {"item" "<MyType 17>"}))))


### PR DESCRIPTION
The goal of the `ISerializable` protocol is to allow extending the serialization mechanism to custom types, via `extend-protocol`. For example, we can `(extend-protocol ISerializable UUID (serialize [id] ...))` to implement serialization for UUIDs.

This `extend-protocol` call works by redefining the `serialize` function, i.e. creating a new function and changing the `#'serialize` var to point to this new object. The new function knows how to dispatch to the correct implementation for the types specified in the `extend-protocol`.

However, the implementation of `clj-item->db-item` using `partial` captures the value of the `serialize` function at the moment the namespace is loaded. Therefore, it will ignore any further `extend-protocol` calls - these will replaced the value referenced by the `#'serialize` var, but the `clj-item->db-item` function will still hold a reference to the original `serialize` function object.

To solve this, we have to ensure we always go through the `#'serialize` var when we run `clj-item->db-item`. This can be done in one of two ways:
* Make `partial` capture the `#'serialize` var, instead of the value of that var:
```clj
(partial utils/name-map #'serialize)
```
* Avoid partial altogether and just use normal function call syntax to call `serialize`. This will look up the `serialize` symbol in the `faraday` namespace, which will point to the `#'serialize` var, which in turn will point to the update `serialize` function object`
```
(defn clj-item->db-item [item]
  (utils/name-map serialize item))
```

I choose the latter solution because it seemed easier to understand.