### PR TITLE
Update deps and drop Clojure 1.5.1 and 1.6 support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.taoensso/faraday "1.11.5-SNAPSHOT"
+(defproject com.taoensso/faraday "1.12.0-SNAPSHOT"
   :author "Peter Taoussanis <https://www.taoensso.com>"
   :description "Clojure DynamoDB client"
   :url "https://github.com/ptaoussanis/faraday"
@@ -11,26 +11,24 @@
                 *assert* true}
 
   :dependencies
-  [[org.clojure/clojure "1.5.1"]
-   [com.taoensso/encore "2.127.0" :exclusions [org.clojure/tools.reader]]
-   [com.taoensso/nippy  "2.15.3"]
-   [joda-time           "2.10.10"]
+  [[org.clojure/clojure "1.7.0"]
+   [com.taoensso/encore "3.24.0" :exclusions [org.clojure/tools.reader]]
+   [com.taoensso/nippy  "3.2.0"]
+   [joda-time           "2.10.14"]
    [commons-logging     "1.2"]
-   [com.amazonaws/aws-java-sdk-dynamodb "1.11.1034"
+   [com.amazonaws/aws-java-sdk-dynamodb "1.12.263"
     :exclusions [joda-time commons-logging]]]
 
   :profiles
   {:server-jvm {:jvm-opts ^:replace ["-server"]}
-   :1.5  {:dependencies [[org.clojure/clojure "1.5.1"]]}
-   :1.6  {:dependencies [[org.clojure/clojure "1.6.0"]]}
    :1.7  {:dependencies [[org.clojure/clojure "1.7.0"]]}
    :1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}
    :1.9  {:dependencies [[org.clojure/clojure "1.9.0"]]}
    :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
    :dev
    [:1.10 :server-jvm
-    {:dependencies [[org.testcontainers/testcontainers "1.15.1"]
-                    [org.slf4j/slf4j-simple "1.7.30"]]
+    {:dependencies [[org.testcontainers/testcontainers "1.17.3" :exclusions [com.fasterxml.jackson.core/jackson-annotations]]
+                    [org.slf4j/slf4j-simple "1.7.36"]]
      :plugins [[lein-ancient "0.6.14"]
                [lein-codox   "0.10.6"]]}]}
 
@@ -41,7 +39,7 @@
    :source-uri "https://github.com/ptaoussanis/faraday/blob/master/{filepath}#L{line}"}
 
   :aliases
-  {"test-all" ["with-profile" "+1.10:+1.9:+1.8:+1.7:+1.6:+1.5" "test"]}
+  {"test-all" ["with-profile" "+1.10:+1.9:+1.8:+1.7" "test"]}
 
   :release-tasks [["vcs" "assert-committed"]
                   ["change" "version" "leiningen.release/bump-version" "release"]


### PR DESCRIPTION
- Updated encore and nippy (requires Clojure 1.7.0+)
- Updated AWS SDK to 1.12.x
- Other minor dep upgrades