### PR TITLE
Faraday2 client

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,3 +24,51 @@
 - [ ] Global tables
 - [ ] Triggers
 - [ ] Tags
+
+## AWS SDK 2 migration
+
+- [x] Client/credentials
+- [ ] Non-blocking operations support
+- [ ] Readme documentation
+
+### Migrate faraday 1 api
+
+- [ ] query
+- [ ] update-ttl
+- [ ] ensure-table
+- [ ] batch-write-item
+- [ ] transact-write-items
+- [ ] clj-item->db-item
+- [ ] describe-ttl
+- [ ] serialize
+- [ ] get-stream-records
+- [ ] create-table
+- [ ] scan-parallel
+- [ ] batch-get-item
+- [ ] freeze
+- [ ] AsMap
+- [ ] update-table
+- [ ] get-item
+- [ ] without-attr-multi-vs
+- [ ] with-attr-multi-vs
+- [ ] transact-get-items
+- [ ] update-item
+- [ ] put-item
+- [ ] items-by-attrs
+- [ ] delete-item
+- [ ] *attr-multi-vs?*
+- [ ] scan-lazy-seq
+- [ ] delete-table
+- [ ] describe-table
+- [ ] ensure-ttl
+- [ ] list-streams
+- [ ] list-tables
+- [ ] shard-iterator
+- [ ] ISerializable
+- [ ] describe-stream
+- [ ] ex
+- [ ] db-item->clj-item
+- [ ] with-thaw-opts
+- [ ] as-map
+- [ ] scan
+- [ ] remove-empty-attr-vals

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,11 @@
    [joda-time           "2.12.5"]
    [commons-logging     "1.2"]
    [com.amazonaws/aws-java-sdk-dynamodb "1.12.693"
-    :exclusions [joda-time commons-logging]]]
+    :exclusions [joda-time commons-logging]]
+   [com.cognitect.aws/api "0.8.741"]
+   [com.cognitect.aws/dynamodb "871.2.31.23"]
+   [com.cognitect.aws/endpoints "871.2.31.23"]
+   [com.cognitect.aws/streams-dynamodb "871.2.29.35"]]
 
   :test-paths ["test" #_"src"]
 

--- a/src/taoensso/faraday2.clj
+++ b/src/taoensso/faraday2.clj
@@ -3,7 +3,7 @@
   (:require [cognitect.aws.client.api :as aws])
   (:import [cognitect.aws.client.impl Client]))
 
-(def ^:private db-client*
+(defn- db-client*
   "Returns a Client instance for the supplied client opts:
     (db-client* {:credentials-provider (cognitect.aws.credentials/basic-credentials-provider
                                          {:access-key-id \"ABC\"
@@ -12,10 +12,10 @@
                                          \"myprofile\")})
 
   See https://github.com/cognitect-labs/aws-api#credentials"
-  (memoize (fn [client-opts]
-             (aws/client (assoc client-opts :api :dynamodb)))))
+  [client-opts]
+  (aws/client (assoc client-opts :api :dynamodb)))
 
-(def ^:private db-streams-client*
+(defn- db-streams-client*
   "Returns a Client instance for the supplied client opts:
     (db-streams-client* {:credentials-provider (cognitect.aws.credentials/basic-credentials-provider
                                                  {:access-key-id \"ABC\"
@@ -24,8 +24,8 @@
                                                  \"myprofile\")})
 
   See https://github.com/cognitect-labs/aws-api#credentials"
-  (memoize (fn [client-opts]
-             (aws/client (assoc client-opts :api :streams-dynamodb)))))
+  [client-opts]
+  (aws/client (assoc client-opts :api :streams-dynamodb)))
 
 (defn- db-client ^Client
   [{:keys [client] :as client-opts}]

--- a/src/taoensso/faraday2.clj
+++ b/src/taoensso/faraday2.clj
@@ -1,0 +1,36 @@
+(ns taoensso.faraday2
+  "Clojure DynamoDB client using the AWS SDK v2 via https://github.com/cognitect-labs/aws-api"
+  (:require [cognitect.aws.client.api :as aws])
+  (:import [cognitect.aws.client.impl Client]))
+
+(def ^:private db-client*
+  "Returns a Client instance for the supplied client opts:
+    (db-client* {:credentials-provider (cognitect.aws.credentials/basic-credentials-provider
+                                         {:access-key-id \"ABC\"
+                                          :secret-access-key \"XYZ\"})})
+    (db-client* {:credentials-provider (cognitect.aws.credentials/profile-credentials-provider
+                                         \"myprofile\")})
+
+  See https://github.com/cognitect-labs/aws-api#credentials"
+  (memoize (fn [client-opts]
+             (aws/client (assoc client-opts :api :dynamodb)))))
+
+(def ^:private db-streams-client*
+  "Returns a Client instance for the supplied client opts:
+    (db-streams-client* {:credentials-provider (cognitect.aws.credentials/basic-credentials-provider
+                                                 {:access-key-id \"ABC\"
+                                                  :secret-access-key \"XYZ\"})})
+    (db-streams-client* {:credentials-provider (cognitect.aws.credentials/profile-credentials-provider
+                                                 \"myprofile\")})
+
+  See https://github.com/cognitect-labs/aws-api#credentials"
+  (memoize (fn [client-opts]
+             (aws/client (assoc client-opts :api :streams-dynamodb)))))
+
+(defn- db-client ^Client
+  [{:keys [client] :as client-opts}]
+  (or client (db-client* client-opts)))
+
+(defn- db-streams-client ^Client
+  [{:keys [client] :as client-opts}]
+  (or client (db-streams-client* client-opts)))

--- a/test/taoensso/faraday2/tests/main.clj
+++ b/test/taoensso/faraday2/tests/main.clj
@@ -1,0 +1,52 @@
+(ns taoensso.faraday2.tests.main
+  (:require
+    [clojure.test :refer [deftest is use-fixtures]]
+    [cognitect.aws.client.api :as aws]
+    [cognitect.aws.credentials :as credentials]
+    [taoensso.faraday2 :as far2])
+  (:import
+    [java.net URI]
+    [org.testcontainers.containers GenericContainer]))
+
+(defmethod clojure.test/report :begin-test-var [m]
+  (println "\u001B[32mTesting" (-> m :var meta :name) "\u001B[0m"))
+
+;;;; Config & setup
+
+(def ^:dynamic *client-opts*
+  (let [endpoint (or (get (System/getenv) "AWS_DYNAMODB_ENDPOINT") "http://localhost:6798")
+        url (.toURL (new URI endpoint))]
+    {:credentials-provider (credentials/basic-credentials-provider
+                             {:access-key-id (or (get (System/getenv) "AWS_DYNAMODB_ACCESS_KEY") "test")
+                              :secret-access-key (or (get (System/getenv) "AWS_DYNAMODB_SECRET_KEY") "test")})
+     :endpoint-override {:protocol (keyword (.getProtocol url))
+                         :hostname (.getHost url)
+                         :port (.getPort url)}
+     :region "eu-west-2"}))
+
+(defn- dynamodb-local
+  [t]
+  (let [dynamodb-port 8000
+        container (doto (GenericContainer. "amazon/dynamodb-local:2.0.0")
+                        (.addExposedPort (int dynamodb-port))
+                        (.start))
+        local-port (.getMappedPort container dynamodb-port)]
+    (with-open [_ container]
+      (with-bindings {#'*client-opts* (assoc *client-opts* :endpoint-override {:protocol :http
+                                                                               :hostname "localhost"
+                                                                               :port local-port})}
+        (t)))))
+
+(use-fixtures :once dynamodb-local)
+
+(deftest client-creation
+  (let [opts->tables #(aws/invoke (#'far2/db-client %) {:op :ListTables})]
+    (is (vector? (:TableNames (opts->tables *client-opts*))))
+    (is (= {:cognitect.anomalies/category :cognitect.anomalies/incorrect
+            :cognitect.anomalies/message "invalid URI scheme random"}
+           (-> (opts->tables (assoc-in *client-opts* [:endpoint-override :protocol] :random))
+               (dissoc :cognitect.aws/throwable))))
+    (is (= {:cognitect.anomalies/category :cognitect.anomalies/fault
+            :cognitect.anomalies/message "No known endpoint."}
+           (-> (opts->tables (assoc *client-opts* :region "random"))
+               (dissoc :cognitect.aws/throwable))))))


### PR DESCRIPTION
Something small to get the ball rolling and open the discussion on client/credentials management. I guess it makes sense to target a different branch with faraday2 stuff, though I don't have permissions to create one.

I've kept client creation dead simple for consistency with aws-api. I've also provided the option to pass in a client for those who want to manage it in application lifecycle. We might also implement something more elaborate to coerce as many keys as we can from the old `taoensso.faraday/client-params`, though perhaps that would confuse things. Any thoughts on this?

Another question to answer early is how we want to surface errors; aws-api always returns a map, though I think faraday2 should probably still throw exceptions to maintain equivalent behaviour for `try` blocks using `taoensso.faraday/ex`. Unfortunately, that might require some custom exception classes though.